### PR TITLE
Add Vec memory backend with tests

### DIFF
--- a/crates/wasui-memory/src/preview1/backends/mod.rs
+++ b/crates/wasui-memory/src/preview1/backends/mod.rs
@@ -2,3 +2,5 @@
 mod js_sys;
 #[cfg(all(feature = "wasm-bridge", target_arch = "wasm32"))]
 mod wasm_bridge;
+
+mod vec_mem;

--- a/crates/wasui-memory/src/preview1/backends/vec_mem.rs
+++ b/crates/wasui-memory/src/preview1/backends/vec_mem.rs
@@ -1,0 +1,33 @@
+use crate::preview1::{GuestError, GuestMemory, GuestPtr, Memory, MemoryMut};
+
+/// A simple in-memory backend for testing purposes.
+///
+/// `Vec<u8>` is used as the underlying memory. Bounds checks are performed for
+/// every access and an error is returned if the pointer is out of range or
+/// overflows.
+impl Memory for Vec<u8> {
+    fn copy_to_slice(&self, ptr: GuestPtr<[u8]>, dst: &mut [u8]) -> Result<(), GuestError> {
+        let start = ptr.offset_base() as usize;
+        let end = start.checked_add(ptr.len() as usize).ok_or(GuestError::PtrOverflow)?;
+        if end > self.len() {
+            return Err(GuestError::InvalidPointer);
+        }
+        dst.copy_from_slice(&self[start..end]);
+        Ok(())
+    }
+}
+
+impl MemoryMut for Vec<u8> {
+    fn copy_from_slice(&mut self, ptr: GuestPtr<[u8]>, src: &[u8]) -> Result<(), GuestError> {
+        let start = ptr.offset_base() as usize;
+        let end = start.checked_add(ptr.len() as usize).ok_or(GuestError::PtrOverflow)?;
+        if end > self.len() {
+            return Err(GuestError::InvalidPointer);
+        }
+        self[start..end].copy_from_slice(src);
+        Ok(())
+    }
+}
+
+impl GuestMemory for Vec<u8> {}
+

--- a/crates/wasui-memory/tests/memory.rs
+++ b/crates/wasui-memory/tests/memory.rs
@@ -1,0 +1,20 @@
+use wasui_memory::preview1::{GuestPtr, Memory, MemoryMut};
+
+#[test]
+fn read_and_write_u32() {
+    let mut memory = vec![0u8; 8];
+    let ptr = GuestPtr::<u32>::new(0);
+
+    memory.write(ptr, 0x12345678).expect("write should succeed");
+    let value = memory.read(ptr).expect("read should succeed");
+
+    assert_eq!(value, 0x12345678);
+}
+
+#[test]
+fn out_of_bounds_fails() {
+    let memory = vec![0u8; 4];
+    let ptr = GuestPtr::<u32>::new(2);
+
+    assert!(memory.read(ptr).is_err());
+}


### PR DESCRIPTION
## Summary
- add `Vec<u8>` memory backend for preview1 module
- expose module for all builds
- add tests that use the new backend

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684eb1cd3df8833080a398fa8701d921